### PR TITLE
Add Fly worker config and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,37 @@
+# MidJAu
 
 ## Local Docker run
 ```bash
 docker build -t midj-app .
 docker run --rm -p 8000:8000 midj-app
 ```
+
+## Deploying to Fly.io
+
+Two Fly apps are used: one for the web interface and one for the RQ worker.
+
+### Web process
+The default `fly.toml` deploys the web UI using `Dockerfile`.
+Deploy it with:
+```bash
+fly deploy -c fly.toml
+```
+
+### Worker process
+`fly.worker.toml` builds `worker.dockerfile` and runs the RQ worker.
+Create a separate Fly app (for example `my-app-worker`) and deploy:
+```bash
+fly apps create my-app-worker    # only once
+fly deploy -c fly.worker.toml --app my-app-worker
+```
+
+### Required environment variables
+Both apps require the following environment variables (usually set as Fly
+secrets):
+- `REDIS_URL` – connection string to your Redis instance
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+- `AWS_ENDPOINT_URL_S3`, `BUCKET_NAME` and `AWS_REGION`
+- other application settings like `FLASK_SECRET_KEY` and
+  `LICENSE_VALIDATION_URL`
+
+Set them with `fly secrets set` before deploying.

--- a/fly.worker.toml
+++ b/fly.worker.toml
@@ -1,0 +1,20 @@
+# Fly.io worker configuration
+app = 'testing-frosty-paper-8838-worker'
+
+primary_region = 'cdg'
+
+[build]
+  dockerfile = 'worker.dockerfile'
+
+[processes]
+  worker = 'rq worker default'
+
+# Environment variables are typically provided via Fly secrets.
+# These placeholders make it explicit which variables are needed.
+[env]
+  REDIS_URL = "replace-me"
+  AWS_ACCESS_KEY_ID = "replace-me"
+  AWS_SECRET_ACCESS_KEY = "replace-me"
+  AWS_ENDPOINT_URL_S3 = "replace-me"
+  BUCKET_NAME = "replace-me"
+  AWS_REGION = "auto"


### PR DESCRIPTION
## Summary
- configure a separate worker app via `fly.worker.toml`
- document Fly deployment steps and required secrets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a165481d083338028984acd0442dd