### PR TITLE
Use SystemExit for job cancellation

### DIFF
--- a/app/MidjourneyAll.py
+++ b/app/MidjourneyAll.py
@@ -28,7 +28,7 @@ def main(user_email: str | None = None, prompts_file: str | None = None):
         if job:
             if job.is_canceled or job.meta.get("cancel_requested"):
                 print("❌ Job was canceled – exiting early", flush=True)
-                exit(0)  # Or raise Exception("Canceled")        
+                raise SystemExit("Job canceled")
 
     # ── project helpers ────────────────────────────────────────────────────
     from .user_utils import (

--- a/app/MidjourneyU1.py
+++ b/app/MidjourneyU1.py
@@ -48,7 +48,7 @@ def check_cancel():
     if job:
         if job.is_canceled or job.meta.get("cancel_requested"):
             print("❌ Job was canceled – exiting early", flush=True)
-            exit(0)  # Or raise Exception("Canceled")    
+            raise SystemExit("Job canceled")
 
 def get_user_id():
     res = requests.get("https://discord.com/api/v9/users/@me", headers=HEADERS)

--- a/app/MidjourneyU2.py
+++ b/app/MidjourneyU2.py
@@ -48,7 +48,7 @@ def check_cancel():
     if job:
         if job.is_canceled or job.meta.get("cancel_requested"):
             print("❌ Job was canceled – exiting early", flush=True)
-            exit(0)  # Or raise Exception("Canceled")    
+            raise SystemExit("Job canceled")
 
 def get_user_id():
     res = requests.get("https://discord.com/api/v9/users/@me", headers=HEADERS)

--- a/app/MidjourneyU3.py
+++ b/app/MidjourneyU3.py
@@ -48,7 +48,7 @@ def check_cancel():
     if job:
         if job.is_canceled or job.meta.get("cancel_requested"):
             print("❌ Job was canceled – exiting early", flush=True)
-            exit(0)  # Or raise Exception("Canceled")    
+            raise SystemExit("Job canceled")
 
 def get_user_id():
     res = requests.get("https://discord.com/api/v9/users/@me", headers=HEADERS)

--- a/app/MidjourneyU4.py
+++ b/app/MidjourneyU4.py
@@ -48,7 +48,7 @@ def check_cancel():
     if job:
         if job.is_canceled or job.meta.get("cancel_requested"):
             print("❌ Job was canceled – exiting early", flush=True)
-            exit(0)  # Or raise Exception("Canceled")    
+            raise SystemExit("Job canceled")
 
 def get_user_id():
     res = requests.get("https://discord.com/api/v9/users/@me", headers=HEADERS)


### PR DESCRIPTION
## Summary
- raise `SystemExit("Job canceled")` instead of calling `exit(0)`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- manual RQ worker test confirming worker keeps running after `SystemExit`

------
https://chatgpt.com/codex/tasks/task_e_688a589b32f083339fa1f1ac60c0b180