### PR TITLE
Fix boto3 version and newline in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ zope.event==5.1.1
 zope.interface==7.2
 rq==1.15.1
 redis==4.6.0
-boto3
+boto3==1.39.16


### PR DESCRIPTION
## Summary
- pin `boto3` dependency to `1.39.16`
- ensure `requirements.txt` ends with a newline

## Testing
- `pip install -r requirements.txt`
- `docker` command not found; unable to run Docker build

------
https://chatgpt.com/codex/tasks/task_e_688a5bcdd6d08333aead26f7f4690b3e