### PR TITLE
Handle cancelled jobs gracefully

### DIFF
--- a/app/MidjourneyAll.py
+++ b/app/MidjourneyAll.py
@@ -16,6 +16,7 @@ def main(user_email: str | None = None, prompts_file: str | None = None):
     import pandas as pd
     import requests
     from rq import get_current_job
+    from rq.exceptions import CancelJobError
 
     # def check_cancel():
     #     job = get_current_job()
@@ -28,7 +29,7 @@ def main(user_email: str | None = None, prompts_file: str | None = None):
         if job:
             if job.is_canceled or job.meta.get("cancel_requested"):
                 print("❌ Job was canceled – exiting early", flush=True)
-                raise SystemExit("Job canceled")
+                raise CancelJobError("Job canceled")
 
     # ── project helpers ────────────────────────────────────────────────────
     from .user_utils import (

--- a/app/MidjourneyU1.py
+++ b/app/MidjourneyU1.py
@@ -7,6 +7,7 @@ import uuid
 import difflib
 from urllib.parse import urlparse
 from rq import get_current_job
+from rq.exceptions import CancelJobError
 from io import BytesIO
 from app.tigris_utils import download_file_obj, upload_file_path
 import zipfile
@@ -48,7 +49,7 @@ def check_cancel():
     if job:
         if job.is_canceled or job.meta.get("cancel_requested"):
             print("❌ Job was canceled – exiting early", flush=True)
-            raise SystemExit("Job canceled")
+            raise CancelJobError("Job canceled")
 
 def get_user_id():
     res = requests.get("https://discord.com/api/v9/users/@me", headers=HEADERS)

--- a/app/MidjourneyU2.py
+++ b/app/MidjourneyU2.py
@@ -7,6 +7,7 @@ import uuid
 import difflib
 from urllib.parse import urlparse
 from rq import get_current_job
+from rq.exceptions import CancelJobError
 from io import BytesIO
 from app.tigris_utils import download_file_obj, upload_file_path
 import zipfile
@@ -48,7 +49,7 @@ def check_cancel():
     if job:
         if job.is_canceled or job.meta.get("cancel_requested"):
             print("❌ Job was canceled – exiting early", flush=True)
-            raise SystemExit("Job canceled")
+            raise CancelJobError("Job canceled")
 
 def get_user_id():
     res = requests.get("https://discord.com/api/v9/users/@me", headers=HEADERS)

--- a/app/MidjourneyU3.py
+++ b/app/MidjourneyU3.py
@@ -7,6 +7,7 @@ import uuid
 import difflib
 from urllib.parse import urlparse
 from rq import get_current_job
+from rq.exceptions import CancelJobError
 from io import BytesIO
 from app.tigris_utils import download_file_obj, upload_file_path
 import zipfile
@@ -48,7 +49,7 @@ def check_cancel():
     if job:
         if job.is_canceled or job.meta.get("cancel_requested"):
             print("❌ Job was canceled – exiting early", flush=True)
-            raise SystemExit("Job canceled")
+            raise CancelJobError("Job canceled")
 
 def get_user_id():
     res = requests.get("https://discord.com/api/v9/users/@me", headers=HEADERS)

--- a/app/MidjourneyU4.py
+++ b/app/MidjourneyU4.py
@@ -7,6 +7,7 @@ import uuid
 import difflib
 from urllib.parse import urlparse
 from rq import get_current_job
+from rq.exceptions import CancelJobError
 from io import BytesIO
 from app.tigris_utils import download_file_obj, upload_file_path
 import zipfile
@@ -48,7 +49,7 @@ def check_cancel():
     if job:
         if job.is_canceled or job.meta.get("cancel_requested"):
             print("❌ Job was canceled – exiting early", flush=True)
-            raise SystemExit("Job canceled")
+            raise CancelJobError("Job canceled")
 
 def get_user_id():
     res = requests.get("https://discord.com/api/v9/users/@me", headers=HEADERS)


### PR DESCRIPTION
## Summary
- raise `CancelJobError` instead of `SystemExit` in all `check_cancel` helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688aaaf0bb108333a8e14b64e4b340f6