### PR TITLE
Switch to local CancelJobError class

### DIFF
--- a/app/MidjourneyAll.py
+++ b/app/MidjourneyAll.py
@@ -16,7 +16,7 @@ def main(user_email: str | None = None, prompts_file: str | None = None):
     import pandas as pd
     import requests
     from rq import get_current_job
-    from rq.exceptions import CancelJobError
+    from .cancel_job_error import CancelJobError
 
     # def check_cancel():
     #     job = get_current_job()

--- a/app/MidjourneyU1.py
+++ b/app/MidjourneyU1.py
@@ -7,7 +7,7 @@ import uuid
 import difflib
 from urllib.parse import urlparse
 from rq import get_current_job
-from rq.exceptions import CancelJobError
+from .cancel_job_error import CancelJobError
 from io import BytesIO
 from app.tigris_utils import download_file_obj, upload_file_path
 import zipfile

--- a/app/MidjourneyU2.py
+++ b/app/MidjourneyU2.py
@@ -7,7 +7,7 @@ import uuid
 import difflib
 from urllib.parse import urlparse
 from rq import get_current_job
-from rq.exceptions import CancelJobError
+from .cancel_job_error import CancelJobError
 from io import BytesIO
 from app.tigris_utils import download_file_obj, upload_file_path
 import zipfile

--- a/app/MidjourneyU3.py
+++ b/app/MidjourneyU3.py
@@ -7,7 +7,7 @@ import uuid
 import difflib
 from urllib.parse import urlparse
 from rq import get_current_job
-from rq.exceptions import CancelJobError
+from .cancel_job_error import CancelJobError
 from io import BytesIO
 from app.tigris_utils import download_file_obj, upload_file_path
 import zipfile

--- a/app/MidjourneyU4.py
+++ b/app/MidjourneyU4.py
@@ -7,7 +7,7 @@ import uuid
 import difflib
 from urllib.parse import urlparse
 from rq import get_current_job
-from rq.exceptions import CancelJobError
+from .cancel_job_error import CancelJobError
 from io import BytesIO
 from app.tigris_utils import download_file_obj, upload_file_path
 import zipfile

--- a/app/cancel_job_error.py
+++ b/app/cancel_job_error.py
@@ -1,0 +1,2 @@
+class CancelJobError(Exception):
+    pass


### PR DESCRIPTION
## Summary
- define `CancelJobError` inside project
- import the new error class across Midjourney modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688abaa9546483339ef94ed0042e08e7