### PR TITLE
Clear user log before dashboard POST processing

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -398,6 +398,8 @@ def dashboard():
             return redirect(url_for("dashboard"))
 
         # ⏩ Continue with script execution if license is still valid
+        # Clear any previous live output log before proceeding
+        redis_conn.delete(get_user_log_key(email))
         mode = request.form["mode"]
         file = request.files["prompt_file"]
 
@@ -535,9 +537,6 @@ def dashboard():
 
             # File was uploaded — you can display the filename
             filename = file.filename
-
-            # ✅ Clear old live output before starting the new job
-            redis_conn.delete(get_user_log_key(email))
 
             env = os.environ.copy()
             env["PROMPTS_FILE"] = presigned_url


### PR DESCRIPTION
## Summary
- Clear any previous user log immediately after license verification in dashboard POST handler
- Remove redundant later log clearing to ensure early returns occur after log reset

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68938bdc1d448333bea4b86c3f3e9ef9