### PR TITLE
Handle failed starts after quota errors

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -508,6 +508,7 @@ def dashboard():
                     row_count=row_count,
                     duration_estimate=None,
                     queue_eta=None,
+                    start_failed=True,
                 )
             if prompts_today + row_count > daily_quota:
                 flash(f"❌ Daily quota exceeded! You have used {prompts_today}/{daily_quota} prompts today.", "error")
@@ -518,6 +519,7 @@ def dashboard():
                     row_count=row_count,
                     duration_estimate=None,
                     queue_eta=None,
+                    start_failed=True,
                 )
                 
 

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -136,6 +136,15 @@
     clearBtn.textContent = "Processing...";
   }
 
+  if ({{ start_failed|default(false)|tojson }}) {
+    localStorage.setItem("scriptRunning", "false");
+    sessionStorage.removeItem("scriptStarted");
+    runBtn.disabled = false;
+    runBtn.textContent = "Start";
+    clearBtn.disabled = false;
+    clearBtn.textContent = "🧹 Clear Output";
+  }
+
   function handleSubmit() {
     localStorage.setItem("scriptRunning", "true");
     sessionStorage.setItem("scriptStarted", "true");


### PR DESCRIPTION
## Summary
- When quota or daily-quota errors occur, flag the dashboard render as a failed start
- On page load after a failed start, reset stored state and re-enable Start and Clear buttons

## Testing
- `pytest`
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68938d2792d08333820df91aa43c5f2b