### PR TITLE
Add subscription details page

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -720,6 +720,28 @@ def settings():
     return render_template("settings.html", settings=current_settings)
 
 
+@app.route("/subscription")
+def subscription():
+    if "email" not in session:
+        return redirect(url_for("login"))
+
+    email = session["email"]
+    key   = session.get("saved_key") or session.get("key")
+
+    info = check_license_and_quota(email, key)
+    if not info.get("success"):
+        flash("⚠️ Unable to fetch subscription data.", "error")
+        return redirect(url_for("dashboard"))
+
+    details = {
+        "tier": info.get("tier"),
+        "expiry": info.get("expiry"),
+        "daily_quota": info.get("dailyQuota"),
+        "job_quota": info.get("jobQuota"),
+        "prompts_today": info.get("promptsToday"),
+    }
+    return render_template("subscription.html", details=details)
+
 
 @app.route('/download_zip')
 def download_zip():

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -303,9 +303,14 @@
       
 
     <nav class="nav-tabs">
-        <a href="{{ url_for('login') }}" class="{% if request.endpoint == 'login' %}active{% endif %}">Login</a>
-        <a href="{{ url_for('dashboard') }}" class="{% if request.endpoint == 'dashboard' %}active{% endif %}">Dashboard</a>
-        <a href="{{ url_for('settings') }}" class="{% if request.endpoint == 'settings' %}active{% endif %}">Settings</a>
+        <a href="{{ url_for('login') }}"
+           class="{% if request.endpoint == 'login' %}active{% endif %}">Login</a>
+        <a href="{{ url_for('dashboard') }}"
+           class="{% if request.endpoint == 'dashboard' %}active{% endif %}">Dashboard</a>
+        <a href="{{ url_for('settings') }}"
+           class="{% if request.endpoint == 'settings' %}active{% endif %}">Settings</a>
+        <a href="{{ url_for('subscription') }}"
+           class="{% if request.endpoint == 'subscription' %}active{% endif %}">Subscription</a>
     </nav>
 
     <!-- 🔔 Toast Notification Container -->

--- a/app/templates/subscription.html
+++ b/app/templates/subscription.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block title %}Subscription | MidjyAuto{% endblock %}
+
+{% block extra_style %}
+<style>
+  .sub-table {
+    margin: 0 auto;
+    border-collapse: collapse;
+    width: 100%;
+    max-width: 500px;
+  }
+  .sub-table th, .sub-table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+  }
+  .sub-table th {
+    background-color: #007bff;
+    color: white;
+    text-align: left;
+    width: 50%;
+  }
+  .sub-table tr:nth-child(even) {
+    background-color: #f2f2f2;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+  <h2 class="title">💳 My Subscription</h2>
+  <table class="sub-table">
+    <tr><th>Tier</th><td>{{ details.tier }}</td></tr>
+    <tr><th>Expiry Date</th><td>{{ details.expiry }}</td></tr>
+    <tr><th>Daily Quota</th><td>{{ details.daily_quota }}</td></tr>
+    <tr><th>Job Quota</th><td>{{ details.job_quota }}</td></tr>
+    <tr><th>Prompts Processed Today</th><td>{{ details.prompts_today }}</td></tr>
+  </table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add subscription route displaying license info
- extend navigation with subscription link
- show subscription details in new template

## Testing
- `python -m py_compile app/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893ba5fab7883338db22730bcefea55