### PR TITLE
Guard job state reset after login

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -55,7 +55,7 @@
   let suppressDownload = true;
   const justLoggedIn = document.getElementById("login-flag")?.dataset.justLoggedIn === "true";
 
-  if (justLoggedIn) {
+  if (justLoggedIn && localStorage.getItem("scriptRunning") !== "true") {
     localStorage.setItem("scriptRunning", "false");
     sessionStorage.removeItem("scriptStarted");
   }


### PR DESCRIPTION
## Summary
- Prevent job state reset on initial page load when a job has just been submitted

## Testing
- `pytest`
- `NODE_PATH=$(npm root -g) node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_6894aff0db748333a51b005526154dc5