### PR TITLE
Remove Bot Token field from settings template

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -18,9 +18,6 @@
     <label>User Token:</label>
     <input type="text" name="user_token" value="{{ settings['USER TOKEN'] }}">
 
-    <label>Bot Token:</label>
-    <input type="text" name="bot_token" value="{{ settings['BOT TOKEN'] }}">
-
     <label>Channel ID:</label>
     <input type="text" name="channel_id" value="{{ settings['CHANNEL ID'] }}">
 


### PR DESCRIPTION
## Summary
- remove Bot Token label and input from settings page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894fb5f0e3483339d338c57a976fcbb