### PR TITLE
Re-enable Start button after settings download failure

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -556,6 +556,7 @@ def dashboard():
                         row_count=row_count,
                         duration_estimate=duration_estimate,
                         queue_eta=queue_eta,
+                        start_failed=True,
                         queue_position=None,
                         queue_eta_minutes=None,
                     )


### PR DESCRIPTION
## Summary
- Ensure settings download failures mark `start_failed` so the dashboard re-enables Start and Clear Output buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68950a1b966083339b67d7a8d4a94a8f