### PR TITLE
Enable autostart configuration for worker tiers

### DIFF
--- a/fly.worker.tier1.toml
+++ b/fly.worker.tier1.toml
@@ -11,3 +11,7 @@ primary_region = "cdg"
   cpu_kind = "shared"
   cpus = 1
 
+[http_service]
+  auto_start_machines = true
+  auto_stop_machines = "stop"
+

--- a/fly.worker.tier2.toml
+++ b/fly.worker.tier2.toml
@@ -11,3 +11,7 @@ primary_region = "cdg"
   cpu_kind = "shared"
   cpus = 1
 
+[http_service]
+  auto_start_machines = true
+  auto_stop_machines = "stop"
+

--- a/fly.worker.tier3.toml
+++ b/fly.worker.tier3.toml
@@ -11,3 +11,7 @@ primary_region = "cdg"
   cpu_kind = "shared"
   cpus = 1
 
+[http_service]
+  auto_start_machines = true
+  auto_stop_machines = "stop"
+


### PR DESCRIPTION
## Summary
- enable autostart and autostop on worker tier configs via [http_service]

## Testing
- `pytest`
- `flyctl machine update dummy --autostart --autostop` *(fails: command not found)*
- `flyctl machine list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689698785c588333bf2b7aab2e53c83a