### PR TITLE
Ensure worker tiers keep an active machine

### DIFF
--- a/fly.worker.tier1.toml
+++ b/fly.worker.tier1.toml
@@ -13,5 +13,6 @@ primary_region = "cdg"
 
 [http_service]
   auto_start_machines = true
-  auto_stop_machines = "stop"
+  auto_stop_machines = "suspend"
+  min_machines_running = 1
 

--- a/fly.worker.tier2.toml
+++ b/fly.worker.tier2.toml
@@ -13,5 +13,6 @@ primary_region = "cdg"
 
 [http_service]
   auto_start_machines = true
-  auto_stop_machines = "stop"
+  auto_stop_machines = "suspend"
+  min_machines_running = 1
 

--- a/fly.worker.tier3.toml
+++ b/fly.worker.tier3.toml
@@ -13,5 +13,6 @@ primary_region = "cdg"
 
 [http_service]
   auto_start_machines = true
-  auto_stop_machines = "stop"
+  auto_stop_machines = "suspend"
+  min_machines_running = 1
 


### PR DESCRIPTION
## Summary
- configure tiered worker Fly configs to keep a machine warm

## Testing
- `pytest`
- `fly deploy --config fly.worker.tier1.toml --dockerfile worker.tier1.dockerfile --app midjau-worker-tier1 --no-cache` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975bb295848333af5eed3837fe8a01