### PR TITLE
Add autoscaler Dockerfile and Fly config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ fly apps create my-app-worker    # only once
 fly deploy -c fly.worker.toml --app my-app-worker
 ```
 
+### Autoscaler process
+`fly.autoscaler.toml` builds `autoscaler.Dockerfile` and runs the queue monitor
+that scales worker machines up or down.
+Deploy it with:
+```bash
+fly deploy -c fly.autoscaler.toml
+```
+
 ### Required environment variables
 Both apps require the following environment variables (usually set as Fly
 secrets):
@@ -47,6 +55,8 @@ fly deploy --config fly.worker.tier1.toml --dockerfile worker.tier1.dockerfile -
 fly deploy --config fly.worker.tier2.toml --dockerfile worker.tier2.dockerfile --app midjau-worker-tier2 --no-cache
 
 fly deploy --config fly.worker.tier3.toml --dockerfile worker.tier3.dockerfile --app midjau-worker-tier3 --no-cache
+
+fly deploy -c fly.autoscaler.toml
 
 ### Commands to show logs
 fly logs --app midjau-web

--- a/autoscaler.Dockerfile
+++ b/autoscaler.Dockerfile
@@ -1,0 +1,22 @@
+# autoscaler.Dockerfile
+FROM python:3.11-slim
+
+# 1. Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+# 2. Set working directory
+WORKDIR /app
+
+# 3. Copy queue monitor script
+COPY scripts/queue_monitor_existing.py /app/queue_monitor_existing.py
+
+# 4. Install Python dependencies
+RUN pip install --no-cache-dir redis rq
+
+# 5. Set environment variables
+ENV PYTHONUNBUFFERED=1
+
+# 6. Run the queue monitor
+CMD ["python", "queue_monitor_existing.py"]

--- a/fly.autoscaler.toml
+++ b/fly.autoscaler.toml
@@ -1,0 +1,17 @@
+# fly.autoscaler.toml for queue monitor autoscaler
+
+app = "midjau-autoscaler"
+primary_region = "cdg"
+
+[build]
+  dockerfile = "autoscaler.Dockerfile"
+
+[http_service]
+  auto_start_machines = true
+  auto_stop_machines = "off"
+  min_machines_running = 1
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1


### PR DESCRIPTION
## Summary
- Add `autoscaler.Dockerfile` for queue monitor autoscaler
- Add `fly.autoscaler.toml` for a small autoscaler VM
- Document autoscaler deployment instructions in `README.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689766b4c434833388a0d6450d805298