### PR TITLE
Add Canva automation page and worker

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -9,6 +9,8 @@ from app.MidjourneyAll import main as run_all
 
 # Optional: for debugging or status tracking later
 from rq import get_current_job
+import os
+import requests
 
 mode_map = {
     "U1": run_u1,
@@ -23,3 +25,44 @@ def run_mode(mode, user_email, prompts_file, key):
     if mode not in mode_map:
         raise ValueError(f"❌ Invalid mode: {mode}")
     return mode_map[mode](user_email, prompts_file, key)
+
+
+def run_canva(rows, api_key, template_id):
+    job = get_current_job()
+    headers = {"Authorization": f"Bearer {api_key}"}
+    results = []
+    for idx, row in enumerate(rows):
+        if job and (job.is_canceled or job.meta.get("cancel_requested")):
+            break
+
+        data = {"template_id": template_id}
+        for k, v in row.items():
+            if k not in {"image_path", "images"}:
+                data[k] = v
+
+        files = {}
+        image_path = row.get("image_path")
+        if image_path and os.path.exists(image_path):
+            files["image"] = open(image_path, "rb")
+
+        try:
+            resp = requests.post(
+                "https://api.canva.com/v1/designs",
+                headers=headers,
+                data=data,
+                files=files or None,
+                timeout=30,
+            )
+            resp.raise_for_status()
+            results.append(resp.json())
+        except Exception as e:
+            results.append({"row": idx, "error": str(e)})
+        finally:
+            if files:
+                files["image"].close()
+
+        if job:
+            job.meta["completed_prompts"] = idx + 1
+            job.save_meta()
+
+    return results

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -307,6 +307,8 @@
            class="{% if request.endpoint == 'login' %}active{% endif %}">Login</a>
         <a href="{{ url_for('dashboard') }}"
            class="{% if request.endpoint == 'dashboard' %}active{% endif %}">Dashboard</a>
+        <a href="{{ url_for('canva') }}"
+           class="{% if request.endpoint == 'canva' %}active{% endif %}">Canva</a>
         <a href="{{ url_for('settings') }}"
            class="{% if request.endpoint == 'settings' %}active{% endif %}">Settings</a>
         <a href="{{ url_for('subscription') }}"

--- a/app/templates/canva.html
+++ b/app/templates/canva.html
@@ -1,0 +1,106 @@
+{% extends "base.html" %}
+
+{% block title %}Canva | MidjyAuto{% endblock %}
+
+{% block content %}
+<h2 class="title">🎨 Canva Automation</h2>
+
+<form method="POST" enctype="multipart/form-data" onsubmit="return handleSubmit();">
+    <label class="form-label">Upload Spreadsheet:</label>
+    <input type="file" name="spreadsheet" required>
+
+    <label class="form-label" style="margin-top: 20px;">Upload Images:</label>
+    <input type="file" name="images" multiple>
+
+    <label class="form-label" style="margin-top: 20px;">Canva API Key:</label>
+    <input type="text" name="api_key" required>
+
+    <label class="form-label" style="margin-top: 20px;">Template ID:</label>
+    <input type="text" name="template_id" required>
+
+    <div style="display: flex; justify-content: center; gap: 10px; margin-top: 20px;">
+        <button type="submit" id="run-canva-btn" class="save-btn">Start</button>
+        <button type="button" id="cancel-canva-btn" class="save-btn">Cancel</button>
+    </div>
+
+    <div id="queue-eta-area" style="text-align:center; margin-top:10px;">
+        <p>Not running! Upload a spreadsheet and hit Start.</p>
+    </div>
+
+    <div id="job-eta-box" style="text-align:center; margin-top:5px;"></div>
+</form>
+
+<script>
+const runBtn = document.getElementById('run-canva-btn');
+const cancelBtn = document.getElementById('cancel-canva-btn');
+let jobProgressInterval = null;
+
+function handleSubmit() {
+  runBtn.disabled = true;
+  runBtn.textContent = 'Processing...';
+  cancelBtn.disabled = true;
+  cancelBtn.textContent = 'Processing...';
+  return true;
+}
+
+cancelBtn.addEventListener('click', () => {
+  fetch('/cancel', {method: 'POST'})
+    .then(() => {
+      runBtn.disabled = false;
+      runBtn.textContent = 'Start';
+      cancelBtn.disabled = false;
+      cancelBtn.textContent = 'Cancel';
+    });
+});
+
+function updateQueueEta() {
+  fetch('/queue_eta')
+    .then(res => res.json())
+    .then(data => {
+      let msg = '';
+      if (data.num_workers === 0) {
+        msg = '<b>No workers are currently available. Please try again later.</b>';
+      } else if (data.position === 0) {
+        msg = '<b>Your job is running now!</b>';
+        if (!jobProgressInterval) {
+          updateJobProgress();
+          jobProgressInterval = setInterval(updateJobProgress, 3000);
+        }
+      } else if (data.position > 0) {
+        msg = `<b>Queued – position ${data.position}, ~${data.eta_minutes} min to start</b>`;
+        if (jobProgressInterval) {
+          clearInterval(jobProgressInterval);
+          jobProgressInterval = null;
+          document.getElementById('job-eta-box').innerHTML = '';
+        }
+      } else {
+        msg = 'Not running! Upload a spreadsheet and hit Start.';
+        if (jobProgressInterval) {
+          clearInterval(jobProgressInterval);
+          jobProgressInterval = null;
+          document.getElementById('job-eta-box').innerHTML = '';
+        }
+      }
+      document.getElementById('queue-eta-area').innerHTML = '<p>' + msg + '</p>';
+    });
+}
+
+function updateJobProgress() {
+  fetch('/job_progress')
+    .then(res => res.json())
+    .then(data => {
+      const etaBox = document.getElementById('job-eta-box');
+      if (data.status === 'running') {
+        const min = Math.ceil(data.remaining_seconds / 60);
+        etaBox.innerHTML = `<b>Estimated time remaining: ${min} min</b> (${data.completed_prompts} / ${data.total_prompts} done)`;
+      } else {
+        etaBox.innerHTML = '';
+      }
+    })
+    .catch(() => {});
+}
+
+setInterval(updateQueueEta, 3000);
+updateQueueEta();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Canva tab to navigation and new Canva page for spreadsheet and image uploads
- support Canva jobs: route to parse uploads, enqueue worker, and track progress
- implement `run_canva` RQ task that calls Canva API per row

## Testing
- `pytest`
- `python -m py_compile app/app.py app/tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_6897c71803a88333a1a53e501395f429