### PR TITLE
Add Excel export and download for generated images

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -283,8 +283,24 @@
               window.URL.revokeObjectURL(url);
             })
             .catch(err => console.error("Failed prompt download error:", err));
+          const imagesExcelDownload = fetch("/download_images_excel")
+            .then(res => {
+              if (!res.ok) throw new Error("Images Excel file not found");
+              return res.blob();
+            })
+            .then(blob => {
+              const url = window.URL.createObjectURL(blob);
+              const link = document.createElement("a");
+              link.href = url;
+              link.download = "images.xlsx";
+              document.body.appendChild(link);
+              link.click();
+              document.body.removeChild(link);
+              window.URL.revokeObjectURL(url);
+            })
+            .catch(err => console.error("Images Excel download error:", err));
 
-          const allDownloads = Promise.all([zipDownload, failedExcelDownload]);
+          const allDownloads = Promise.all([zipDownload, failedExcelDownload, imagesExcelDownload]);
           const fallback = new Promise(resolve => setTimeout(resolve, 10000));
 
           Promise.race([allDownloads, fallback])


### PR DESCRIPTION
## Summary
- Generate `images.xlsx` workbook with embedded images after jobs complete and upload to user storage
- Expose `/download_images_excel` route to serve the workbook and add UI hook to download it alongside ZIP and failed prompts
- Clean up uploaded workbook on server and during cancellations

## Testing
- `python -m py_compile app/midjourney_runner.py app/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897defa627c8333a04f1eb24c8bdb23