### PR TITLE
Expose queued job details on dashboard

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -345,6 +345,8 @@ def dashboard():
 
         selected_mode = queued_info.get('mode')
         initial_queue_pos = queued_info.get('queue_position')
+        queued_total_prompts = queued_info.get('total_prompts')
+        queued_duration = queued_info.get('duration_estimate')
 
         key = session.get("saved_key") or session.get("key")
         license_info = check_license_and_quota(email, key)
@@ -370,6 +372,8 @@ def dashboard():
             queue_eta_minutes=eta_minutes,
             queued_mode=selected_mode,
             queued_position=initial_queue_pos,
+            queued_total_prompts=queued_total_prompts,
+            queued_duration=queued_duration,
         )
 
     # Otherwise, continue with POST logic...
@@ -634,6 +638,8 @@ def dashboard():
                 session['dashboard_counters'] = {
                     'mode': mode,
                     'queue_position': position,
+                    'total_prompts': row_count,
+                    'duration_estimate': duration_estimate,
                 }
 
                 print("🚩 Set dashboard_counters in session:", session['dashboard_counters'], flush=True)

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -27,7 +27,9 @@
     </div>
 
       <div id="queue-eta-area" style="text-align:center; margin-top:10px;">
-        {% if queue_position is not none and queue_position > 0 %}
+        {% if queue_position is not none and queue_position == 0 %}
+          <p><b>Your job is running now! Estimated time remaining: {{ queued_duration }} min (0 / {{ queued_total_prompts }} prompts done).</b></p>
+        {% elif queue_position is not none and queue_position > 0 %}
           <p><b>Queued in {{ queued_mode }} – position {{ queue_position }}, ~{{ queue_eta_minutes }} min to start</b></p>
         {% else %}
           <p>Not running! Upload an Excel file, select your mode and hit Start.</p>


### PR DESCRIPTION
## Summary
- Save total prompts and estimated duration alongside mode and queue position when queuing jobs
- Surface queued job's total prompts and duration on dashboard GET handler
- Show running-job status with estimated remaining time in dashboard template

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c993f67f08333bd2b2fda8e4f5506