### PR TITLE
Handle invalid license caching and access denial

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -58,6 +58,8 @@ redis_conn = Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
 
 # Cache license lookups for a short time to avoid repeated network calls
 LICENSE_CACHE_TTL = int(os.getenv("LICENSE_CACHE_TTL", "300"))  # seconds
+# Last-known valid license info cache TTL (fallback when quota check fails)
+LICENSE_LAST_TTL = int(os.getenv("LICENSE_LAST_TTL", "86400"))  # seconds
 
 
 def get_cached_license_info(email: str, license_key: str) -> dict:
@@ -80,12 +82,21 @@ def get_cached_license_info(email: str, license_key: str) -> dict:
     if info.get("success"):
         try:
             redis_conn.setex(cache_key, LICENSE_CACHE_TTL, json.dumps(info))
-            redis_conn.set(last_key, json.dumps(info))
+            # Store the last known valid info with a TTL to avoid indefinite reuse
+            redis_conn.setex(last_key, LICENSE_LAST_TTL, json.dumps(info))
         except Exception as e:
             print(f"Failed to cache license info: {e}")
         return info
 
-    # If lookup failed, attempt to return the last known value
+    # If the license is invalid or expired, remove any previous cache and return immediately
+    if info.get("reason") != "Quota check failed":
+        try:
+            redis_conn.delete(last_key)
+        except Exception:
+            pass
+        return info
+
+    # On quota check failures (network/validation error), fall back to last known value
     last = redis_conn.get(last_key)
     if last:
         try:


### PR DESCRIPTION
## Summary
- Avoid reusing stale license info when validation fails for reasons other than quota checks
- Add TTL to license_last cache and clear stale entries on invalid or expired licenses
- Ensure login and job submission reject requests when license validation fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd431a8f48333b565adcb7631d3c8