### PR TITLE
Add Discord token capture via bookmarklet with nonce validation

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -4,6 +4,12 @@
 <div class="settings-container">
   <h2 class="title">⚙️ Settings</h2>
 
+  <p>
+    Click the bookmarklet below while on <code>https://discord.com/app</code>
+    to automatically capture your token:
+    <a href="javascript:(()=>{var t=localStorage.getItem('token');try{t=JSON.parse(t);}catch(e){}if(t){location.href='{{ url_for('receive_token', _external=True) }}?value='+encodeURIComponent(t)+'&state={{ token_nonce }}';}})()">Capture Discord Token</a>
+  </p>
+
   <form method="POST">
     <label>User Token:</label>
     <input type="text" name="user_token" value="{{ settings['USER TOKEN'] }}">


### PR DESCRIPTION
## Summary
- Generate short-lived nonce on settings page and embed in bookmarklet for capturing Discord token.
- Add `/receive_token` endpoint to validate nonce, store token in user settings, and sync to cloud storage.
- Provide bookmarklet link in settings template with instructions for use on discord.com/app.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7fb7c520833385d19dca3d4802e2